### PR TITLE
docs: pre-release sandbox install must use [all] extras (#46)

### DIFF
--- a/docs/development/pre-release-checklist.md
+++ b/docs/development/pre-release-checklist.md
@@ -35,7 +35,7 @@ The script enforces what it can; the rest is judgment that needs a human.
 | 3 | Full test suite | `pytest -q` (includes slow tests) passes |
 | 4 | Ruff lint | `ruff check src/ bench/` clean |
 | 5 | Wheel build | `python -m build` produces `dist/ai_codeindex-VERSION-py3-none-any.whl` |
-| 6 | Clean-venv install | Fresh venv, `pip install dist/*.whl`, `codeindex --version` matches, `codeindex --help` runs |
+| 6 | Clean-venv install | Fresh venv, `pip install "$(ls dist/*.whl)[all]"` (the `[all]` extras pull language parsers — GH #46), `codeindex --version` matches, `codeindex --help` runs |
 | 7 | CI status | `gh run list` shows latest run on current branch succeeded (best-effort) |
 
 If any FAIL, the script exits non-zero and you do not proceed.
@@ -64,11 +64,18 @@ TARGET=/path/to/some/project
 cd $TARGET
 git stash -u   # if it's git, stash anything uncommitted
 
-# Install the candidate version into a sandbox venv
+# Install the candidate version into a sandbox venv.
+# NOTE (GH #46): the `[all]` extras pull the tree-sitter language parsers. A
+# bare `pip install <wheel>` installs only the entrypoint — no parsers — so
+# scan-all emits structural-only READMEs and the upgrade-sim diff won't match
+# what a real `pipx install ai-codeindex[all]` user sees. Quote the arg so the
+# shell doesn't glob `[all]`. Do NOT retrofit with `pip install ai-codeindex[all]`
+# (no --no-deps) — that re-pulls ai-codeindex from PyPI and silently downgrades
+# the sandbox.
 SANDBOX=/tmp/codeindex_upgrade_test
 rm -rf $SANDBOX && python3 -m venv $SANDBOX
-$SANDBOX/bin/pip install dist/ai_codeindex-0.24.0-py3-none-any.whl
-$SANDBOX/bin/codeindex --version    # should print 0.24.0
+$SANDBOX/bin/pip install "$(ls dist/ai_codeindex-*-py3-none-any.whl)[all]"
+$SANDBOX/bin/codeindex --version    # should print the candidate version
 
 # Re-scan
 $SANDBOX/bin/codeindex scan-all --ai


### PR DESCRIPTION
Closes #46.

Bare `pip install <wheel>` installs the entrypoint but no tree-sitter parsers → scan-all emits structural-only READMEs → the upgrade-sim diff doesn't match what a real `pipx install ai-codeindex[all]` user sees. Fix the sandbox + clean-venv install commands to the quoted `<wheel>[all]` form, genericize the hardcoded `0.24.0`, and warn against the `pip install ai-codeindex[all]` PyPI-downgrade trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)