### PR TITLE
chore(release): one pre-release checker; CHANGELOG required, RELEASE_NOTES optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,15 @@ refactor(scope): refactor code
 | Config change | .codeindex.yaml example, CHANGELOG.md |
 | Major release | CHANGELOG.md, docs/releases/RELEASE_NOTES_vX.X.X.md |
 
+**CHANGELOG vs RELEASE_NOTES policy**: `CHANGELOG.md` is the mandatory,
+complete, every-release ledger (terse, categorized — the "what changed"
+lookup). `docs/releases/RELEASE_NOTES_vX.Y.Z.md` is **optional**, written only
+for a major / breaking / announced release — a curated narrative + migration
+guide that doubles as the public announcement. A patch or routine minor needs
+no RELEASE_NOTES; writing one per version is ceremony. The pre-release gate
+(`scripts/pre_release_check.sh`) enforces CHANGELOG and only *warns* on a
+missing RELEASE_NOTES.
+
 After code changes: `codeindex scan-all`
 
 ### Epic Completion Workflow

--- a/Makefile
+++ b/Makefile
@@ -148,58 +148,15 @@ endif
 	@echo "$(GREEN)✓ Updated pyproject.toml$(RESET)"
 	@git diff pyproject.toml
 
-pre-release-check:  ## Pre-release checks (tests, lint, version, docs)
+pre-release-check:  ## Pre-release checks — single source of truth: scripts/pre_release_check.sh
 ifndef VERSION
 	@echo "$(RED)Error: VERSION not specified$(RESET)"
 	@echo "Usage: make release VERSION=0.20.0"
 	@exit 1
 endif
-	@echo "$(CYAN)=== Pre-release checks for v$(VERSION) ===$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[1/7] Checking Git status...$(RESET)"
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		echo "$(RED)Error: Working directory not clean$(RESET)"; \
-		git status --short; \
-		exit 1; \
-	fi
-	@echo "$(GREEN)✓ Working directory clean$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[2/7] Checking branch...$(RESET)"
-	@BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
-	if [ "$$BRANCH" != "master" ]; then \
-		echo "$(RED)Error: Not on master branch (current: $$BRANCH)$(RESET)"; \
-		exit 1; \
-	fi
-	@echo "$(GREEN)✓ On master branch$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[3/7] Running tests...$(RESET)"
-	@pytest -v --tb=short || (echo "$(RED)✗ Tests failed$(RESET)"; exit 1)
-	@echo "$(GREEN)✓ All tests passed$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[4/7] Running linter...$(RESET)"
-	@ruff check src/ tests/ || (echo "$(RED)✗ Lint errors found$(RESET)"; exit 1)
-	@echo "$(GREEN)✓ No lint errors$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[5/7] Checking CHANGELOG entry...$(RESET)"
-	@if ! grep -q "^## \[$(VERSION)\]" CHANGELOG.md; then \
-		echo "$(RED)Error: no '## [$(VERSION)]' section in CHANGELOG.md$(RESET)"; \
-		echo "Move [Unreleased] → [$(VERSION)] before releasing."; \
-		exit 1; \
-	fi
-	@echo "$(GREEN)✓ CHANGELOG has [$(VERSION)] section$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[6/7] Checking version consistency...$(RESET)"
-	@python3 scripts/check_version_consistency.py || \
-		(echo "$(RED)✗ Version inconsistency found$(RESET)"; \
-		echo "Run: python3 scripts/check_version_consistency.py --fix"; exit 1)
-	@echo "$(GREEN)✓ Version consistency OK$(RESET)"
-	@echo ""
-	@echo "$(CYAN)[7/7] Checking documentation consistency...$(RESET)"
-	@python3 scripts/check_docs_release.py || true
-	@echo ""
-	@echo "$(GREEN)=== All pre-release checks passed ===$(RESET)"
+	@bash scripts/pre_release_check.sh $(VERSION)
 
-release: pre-release-check bump-version  ## Full release (usage: make release VERSION=X.Y.Z)
+release: bump-version pre-release-check  ## Full release (usage: make release VERSION=X.Y.Z)
 	@echo ""
 	@echo "$(CYAN)=== Creating release v$(VERSION) ===$(RESET)"
 	@echo ""

--- a/docs/development/pre-release-checklist.md
+++ b/docs/development/pre-release-checklist.md
@@ -30,7 +30,7 @@ The script enforces what it can; the rest is judgment that needs a human.
 
 | # | Check | What it verifies |
 |---|---|---|
-| 1 | Version consistency | `pyproject.toml`, `CHANGELOG.md [VERSION]`, `RELEASE_NOTES_vVERSION.md` present, tag doesn't already exist |
+| 1 | Version consistency | `pyproject.toml` = VERSION, `CHANGELOG.md [VERSION]` present (required), tag doesn't already exist. `RELEASE_NOTES_vVERSION.md` is **optional** (warn only) — write one only for a major/breaking release |
 | 2 | Working tree state | Clean tree, on master branch |
 | 3 | Full test suite | `pytest -q` (includes slow tests) passes |
 | 4 | Ruff lint | `ruff check src/ bench/` clean |

--- a/scripts/pre_release_check.sh
+++ b/scripts/pre_release_check.sh
@@ -51,11 +51,14 @@ else
     fail "CHANGELOG.md missing [$VERSION] section"
 fi
 
+# RELEASE_NOTES are OPTIONAL — CHANGELOG (above) is the mandatory per-release
+# record. Write a RELEASE_NOTES only for a major / breaking / announced release
+# (there it doubles as the announcement). A patch or routine minor needs none.
 NOTES_FILE="docs/releases/RELEASE_NOTES_v${VERSION}.md"
 if [[ -f "$NOTES_FILE" ]]; then
     pass "$NOTES_FILE exists"
 else
-    fail "$NOTES_FILE missing — write release notes first"
+    warn "$NOTES_FILE absent — fine for a patch/minor; write one only for a major or breaking release"
 fi
 
 if git rev-parse "v$VERSION" >/dev/null 2>&1; then


### PR DESCRIPTION
Resolves the two-parallel-checkers finding — which turned out to be two divergent **workflows**, not just duplicate checks: the Makefile target checked *before* bump; `scripts/pre_release_check.sh` (what the checklist uses) assumes pyproject is *already* bumped.

**Single source of truth**
- `make pre-release-check` → delegates to `scripts/pre_release_check.sh`.
- `make release` reordered to **bump-version → check → tag/push** (verified by `make -n`: sed bump → `bash scripts/pre_release_check.sh` → commit/tag/push), so the checker verifies the bumped state. Coherent with the shell script + QUICK_START runbook.

**Policy: CHANGELOG required, RELEASE_NOTES optional** (now in CLAUDE.md + enforced by the one checker)
- `CHANGELOG.md [VERSION]` — required every release (the complete ledger).
- `RELEASE_NOTES_vX.Y.Z.md` — optional, majors/breaking/announced only (doubles as the announcement). Checker now **warns** instead of failing when absent. Per-version notes were ceremony.

⚠️ **Touches release machinery.** Verified by `make -n` dry-run + `bash -n` syntax, **not** by cutting a real release — please eyeball before the next real `make release`. Also: `check_version_consistency.py` / `check_docs_release.py` are no longer auto-run by `make release` (the shell checker does pyproject+CHANGELOG inline); fold them into the shell script if the multi-file version check is wanted back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)