### PR TITLE
docs: two-repo architecture sync + deep-rewrite loomgraph guide + add ADR-007

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,17 +127,23 @@ Read `docs/architecture/design-philosophy.md` when:
 
 ## Part 3: Architecture Reference
 
-### Three-Repo Architecture
+### Two-Repo Architecture
 
-> codeindex **sees** (AST parsing), LoomGraph **thinks** (pipeline + skills), LightRAG **remembers** (storage + retrieval)
+> codeindex **sees** (AST parsing → structural slice), LoomGraph **thinks + remembers**
+> (graph store + vector retrieval + query/MCP)
 
 | Repo | Role | Local Path |
 |------|------|------------|
-| **codeindex** | AST parsing, Symbol/Call/Inheritance extraction | `/Users/dreamlinx/Projects/codeindex` |
-| **LoomGraph** | Pipeline dispatch, Embedding, CLI/Skill | `/Users/dreamlinx/Projects/LoomGraph` |
-| **LightRAG** | Graph storage, vector retrieval | `/Users/dreamlinx/Projects/LightRAG` |
+| **codeindex** | AST parsing, Symbol/Call/Inheritance extraction, `graph-export` NDJSON. **Stateless** (ADR-007). | `/Users/dreamlinx/Projects/opensource/codeindex` |
+| **LoomGraph** | Graph store + vector retrieval (SQLite + sqlite-vec vec0 KNN), embedding, query/MCP. **Stateful.** | `/Users/dreamlinx/Projects/opensource/loomgraph` |
 
-Data flow: `codeindex scan` → ParseResult → `LoomGraph embed/inject` → LightRAG API → PostgreSQL
+Data flow: `codeindex graph-export` → NDJSON → `loomgraph import-export` →
+`SqliteGraphStore` (SQLite + sqlite-vec).
+
+> **Note**: LightRAG is retired from the runtime. LoomGraph's local refactor
+> replaced it with SQLite + sqlite-vec ("no RAG framework needed"); the old
+> `codeindex scan → LoomGraph embed → LightRAG API → PostgreSQL` flow no longer
+> applies. The graph-export NDJSON contract is the sole seam between the two repos.
 
 ### Core Pipeline
 

--- a/README.md
+++ b/README.md
@@ -100,14 +100,16 @@ loomgraph inject parse_results.json  # Build knowledge graph
 # Team can now search code using natural language
 ```
 
-**Three-repo architecture**:
+**Two-repo architecture**:
 ```
-codeindex (Parse)  →  LoomGraph (Orchestrate)  →  LightRAG (Store)
-   ↓ ParseResult         ↓ Embeddings              ↓ Semantic Search
-   AST extraction        Knowledge Graph           Vector + Graph DB
+codeindex (Parse)         →   LoomGraph (Store + Query)
+   ↓ graph-export NDJSON        ↓ SQLite + sqlite-vec
+   AST extraction               Knowledge graph + vector search + MCP
 ```
 
-Without codeindex, LoomGraph cannot function. See [LoomGraph Integration Guide](docs/guides/loomgraph-integration.md).
+codeindex is the stateless parse layer; LoomGraph is the self-contained
+knowledge graph (SQLite + sqlite-vec, no external RAG framework). Without
+codeindex, LoomGraph has nothing to index. See [LoomGraph Integration Guide](docs/guides/loomgraph-integration.md).
 
 ---
 
@@ -422,7 +424,7 @@ After (structural + AI enrichment):
                              ↑ AI agent can navigate directly
 ```
 
-### Three-Repo Architecture (Enterprise Knowledge Graph)
+### Two-Repo Architecture (Enterprise Knowledge Graph)
 
 ```
 ┌────────────────────────────────────────────────────┐
@@ -431,28 +433,29 @@ After (structural + AI enrichment):
 │                                                    │
 │  📦 Code Repository (Git)                          │
 │       ↓                                            │
-│  🔍 codeindex (Parse Layer)                        │
-│       ├── scan --output json → ParseResult         │
+│  🔍 codeindex (Parse Layer — stateless)            │
+│       ├── graph-export → NDJSON graph artifact     │
 │       ├── README_AI.md → architecture docs         │
 │       └── tech-debt → comprehensive quality scan   │
 │       ↓                                            │
-│  🕸️ LoomGraph (Orchestration Layer)                │
-│       ├── inject ParseResult                       │
-│       ├── generate embeddings                      │
-│       └── build knowledge graph                    │
-│       ↓                                            │
-│  💾 LightRAG (Storage Layer)                       │
-│       ├── PostgreSQL (graph data)                  │
-│       ├── Vector DB (embeddings)                   │
-│       └── Query API (semantic search)              │
+│  🕸️ LoomGraph (Store + Query — stateful)           │
+│       ├── import-export ← codeindex NDJSON         │
+│       ├── SQLite + sqlite-vec (graph + vectors)    │
+│       ├── embeddings + KNN semantic search         │
+│       └── query CLI + MCP server                   │
 │       ↓                                            │
 │  💬 AI Agents (Claude Code, Internal Chat)         │
-│       └── Natural language code search             │
+│       └── Natural language code search (MCP)       │
 │                                                    │
 └────────────────────────────────────────────────────┘
 ```
 
-**codeindex role**: Bottom layer (data collection & parsing) — the entire system depends on codeindex providing structured ParseResult data.
+> **Note**: LightRAG + PostgreSQL are no longer part of this flow. LoomGraph's
+> local refactor replaced them with an embedded SQLite + sqlite-vec store
+> ("no RAG framework needed").
+
+**codeindex role**: Bottom layer (parsing) — LoomGraph depends on codeindex's
+`graph-export` NDJSON as the sole data seam. codeindex itself stays stateless (ADR-007).
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -100,14 +100,15 @@ loomgraph inject parse_results.json  # Build knowledge graph
 # Team can now search code using natural language
 ```
 
-**三仓库架构**：
+**两仓库架构**：
 ```
-codeindex (Parse)  →  LoomGraph (Orchestrate)  →  LightRAG (Store)
-   ↓ ParseResult         ↓ Embeddings              ↓ Semantic Search
-   AST extraction        Knowledge Graph           Vector + Graph DB
+codeindex (Parse)         →   LoomGraph (Store + Query)
+   ↓ graph-export NDJSON        ↓ SQLite + sqlite-vec
+   AST extraction               知识图谱 + 向量检索 + MCP
 ```
 
-没有 codeindex，LoomGraph 无法运转。参见 [LoomGraph 集成指南](docs/guides/loomgraph-integration.md)。
+codeindex 是无状态的解析层；LoomGraph 是自包含的知识图谱（SQLite + sqlite-vec，
+无需外部 RAG 框架）。没有 codeindex，LoomGraph 就无内容可索引。参见 [LoomGraph 集成指南](docs/guides/loomgraph-integration.md)。
 
 ---
 
@@ -419,7 +420,7 @@ After (structural + AI enrichment):
                              ↑ AI agent can navigate directly
 ```
 
-### 三仓库架构（企业知识图谱）
+### 两仓库架构（企业知识图谱）
 
 ```
 ┌────────────────────────────────────────────────────┐
@@ -428,28 +429,28 @@ After (structural + AI enrichment):
 │                                                    │
 │  📦 Code Repository (Git)                          │
 │       ↓                                            │
-│  🔍 codeindex (Parse Layer)                        │
-│       ├── scan --output json → ParseResult         │
+│  🔍 codeindex (Parse Layer — 无状态)               │
+│       ├── graph-export → NDJSON 图谱制品           │
 │       ├── README_AI.md → architecture docs         │
 │       └── tech-debt → comprehensive quality scan   │
 │       ↓                                            │
-│  🕸️ LoomGraph (Orchestration Layer)                │
-│       ├── inject ParseResult                       │
-│       ├── generate embeddings                      │
-│       └── build knowledge graph                    │
-│       ↓                                            │
-│  💾 LightRAG (Storage Layer)                       │
-│       ├── PostgreSQL (graph data)                  │
-│       ├── Vector DB (embeddings)                   │
-│       └── Query API (semantic search)              │
+│  🕸️ LoomGraph (Store + Query — 有状态)             │
+│       ├── import-export ← codeindex NDJSON         │
+│       ├── SQLite + sqlite-vec（图谱 + 向量）       │
+│       ├── embeddings + KNN 语义检索                │
+│       └── query CLI + MCP server                   │
 │       ↓                                            │
 │  💬 AI Agents (Claude Code, Internal Chat)         │
-│       └── Natural language code search             │
+│       └── Natural language code search (MCP)       │
 │                                                    │
 └────────────────────────────────────────────────────┘
 ```
 
-**codeindex 角色**：底层（数据采集与解析）——整个系统都依赖 codeindex 提供结构化的 ParseResult 数据。
+> **注**：LightRAG + PostgreSQL 已不在此流程中。LoomGraph 本地化改造后用内嵌的
+> SQLite + sqlite-vec 取代（"no RAG framework needed"）。
+
+**codeindex 角色**：底层（解析）——LoomGraph 以 codeindex 的 `graph-export` NDJSON
+为唯一数据接缝；codeindex 自身保持无状态（ADR-007）。
 
 ---
 

--- a/docs/architecture/adr/007-codeindex-stateless-graph-ownership.md
+++ b/docs/architecture/adr/007-codeindex-stateless-graph-ownership.md
@@ -1,0 +1,116 @@
+# ADR 007: codeindex 无状态 — 持久化图谱归 loomgraph
+
+## 状态
+
+已采纳 (Accepted) — 2026-06-28（随 v0.27.0 `graph-export` 发布落地）
+
+## 背景
+
+LoomGraph#30 消费 spike（verdict 🟡 YELLOW）验证了下游确实需要 codeindex 产出一份
+机读的图谱制品（entity + CALLS/INHERITS），但同时逼出一个必须先拍板的架构问题：
+
+**谁持有持久化的代码图谱状态？**
+
+两仓都"碰"图谱：codeindex 从 AST 抽出符号与边，loomgraph 要把它们存进可增量更新、
+可向量检索、可 topology 分析的知识图谱。如果不划清所有权，可预见的失败模式：
+
+1. **双写状态**：codeindex 若自己维护一份持久 `.db`（增量同步 / 缓存图谱），loomgraph 又
+   维护一份，两份状态会漂移，且"谁是 source of truth" 永远说不清。
+2. **职责错层**：codeindex 的价值在消费侧的导航与结构真值（ADR-005），不在"当一个图数据库"。
+   让它长出 corruption recovery / 向量索引 / 增量 reconcile，是把 loomgraph 的活扛过来。
+3. **export 与 render-flip 混淆**：spike 通过后一度想顺势把 `scan-all` 的内部渲染路径也
+   翻新（#101 Phase 2 render-flip）。但 spike 解锁的是**产出制品**，不是**内部重构**——
+   export 需要的是 buffer 被 *填充*，不是渲染路径被 *翻转*。二者架构独立。
+
+## 决策
+
+**codeindex 是无状态的图谱 emitter；持久化图谱归 loomgraph。**
+
+1. **codeindex 只产出 write-once 制品**：`codeindex graph-export` 对整棵树做一次干净解析，
+   dump 一份 NDJSON（`meta` + `entity` + `edge`）。它**不持有任何持久 / 可变状态**——
+   没有 `.db`、没有增量同步、没有 corruption recovery、没有向量索引。契约规格见
+   [graph-export.md](../../guides/graph-export.md)。
+
+2. **持久化 + 语义层全部归 loomgraph**：可变 `.db`、增量同步、向量（`sqlite-vec`）索引、
+   以及 L3（设计文档级 LLM 抽取）都是 loomgraph 的职责。loomgraph 读这份一次性快照，
+   在其上合成容器节点（file/module）、外部 stub、语义脚手架。
+
+3. **唯一接缝是制品**：进程解耦（decision (a)）——codeindex 不 import loomgraph，
+   loomgraph 通过子进程调 codeindex CLI 拿到 NDJSON。制品是两仓之间**唯一**的数据契约。
+
+4. **codeindex 只发结构切片，不发完整图谱**：只含真实代码符号（class/function/method）
+   及其 CALLS/INHERITS 边，附 `resolution_qualifier` / `provenance_completeness` 元数据，
+   如实标注 AST 抽取与跨文件解析的有损性。容器节点 / 外部 stub 由消费者合成。
+
+## 理由
+
+### 1. 分层：sees vs thinks+remembers
+
+两仓模型：**codeindex sees**（AST → 结构切片），**loomgraph thinks + remembers**
+（图存储 + 向量检索 + query/MCP）。持久化状态天然属于 "remembers" 侧。让 emitter 保持
+无状态，是这条分层的直接推论。
+
+### 2. 单一 source of truth
+
+制品是 write-once 快照，不是可变状态。任何时刻"图谱现在是什么样"只有一个答案——
+loomgraph 的 workspace。codeindex 每次 `graph-export` 都从源码重新生成，无历史包袱、
+无 reconcile。
+
+### 3. 无状态 = 易测、易 CI、易并发
+
+`graph-export` 是纯函数式的 `源码树 → NDJSON`。可在 CI / Docker / 任意目录无副作用运行，
+golden 测试可 diff（见 `tests/test_graph_export.py`）。若 codeindex 持有 `.db`，这些性质
+全部消失。
+
+### 4. export ≠ flip（解耦，不顺势重构）
+
+spike 的 GREEN/YELLOW 只为"produce artifact"背书。内部 render-flip（#101 Phase 2）是
+独立的、可延后的重构：export 从 `GraphBuffer` 读*已填充*的数据，不要求渲染路径先翻转。
+因此 v0.27.0 只 ship export，render-flip 延后，`GraphBuffer` IR 以 dormant（未接线）状态
+随车发布。
+
+## 影响范围
+
+- **新增**：`codeindex graph-export` 命令 + [graph-export.md](../../guides/graph-export.md) 契约文档。
+- **复用**：`GraphBuffer` IR（#101）仅作已解析数据的容器被 export 复用；不 ship 任何持久 /
+  可变状态。
+- **延后**：`scan-all` 内部 render-flip（#101 Phase 2），issue #101 作为 tracker 保持 open。
+- **下游**：loomgraph 通过 `loomgraph import-export` 消费制品，`unresolved` 边计数但跳过存储
+  （不插占位节点，避免污染 topology）。集成见
+  [loomgraph-integration.md](../../guides/loomgraph-integration.md)。
+
+## 替代方案（已否决）
+
+### 方案 1：codeindex 自持久化图谱（`.db` + 增量同步）
+
+- ❌ 双写状态、source-of-truth 不清。
+- ❌ 职责错层——把 loomgraph 的存储 / 向量 / reconcile 活扛过来。
+- ❌ 摧毁无状态带来的可测 / 可 CI / 可并发性质。
+
+### 方案 2：借 export 顺势做 render-flip（#101 Phase 2 一起上）
+
+- ❌ 把"产出制品"和"内部重构"绑成一个大变更，风险叠加。
+- ❌ spike 没为 flip 背书；export 不依赖 flip。延后是更小、更可控的路径。
+
+### 方案 3：codeindex 直接 import loomgraph、进程内传对象
+
+- ❌ 紧耦合，违背两仓独立发版 / 进程隔离（同 ADR-006 的引擎/触达层原则的精神）。
+- ❌ 强绑 Python 环境；CLI 制品接缝对任何语言的消费者都开放。
+
+## 相关 ADR
+
+- ADR 005: 导航契约与 README 大小上限（codeindex 价值在消费侧——本决策的 precedent）。
+- ADR 006: 分发架构拆分（CLI 引擎 vs 触达层；两仓独立发版的同源思路）。
+
+## 参考资料
+
+- 契约规格：[docs/guides/graph-export.md](../../guides/graph-export.md)
+- 集成指南：[docs/guides/loomgraph-integration.md](../../guides/loomgraph-integration.md)
+- LoomGraph#30 消费 spike（verdict 🟡 YELLOW，为 export 背书、未为 flip 背书）
+- 实现：`src/codeindex/graph_export.py`、`src/codeindex/graph_buffer.py`（#101 dormant IR）
+
+---
+
+**决策人**: dreamlinx
+**日期**: 2026-06-28
+**状态**: 已采纳（v0.27.0 已落地）

--- a/docs/guides/loomgraph-integration.md
+++ b/docs/guides/loomgraph-integration.md
@@ -1,92 +1,119 @@
 # LoomGraph 集成指南
 
-**目标读者**: LoomGraph 项目组开发者
-**版本**: codeindex v0.13.0+
-
-> ⚠️ **架构已更新（2026-07，两仓模型）**：本指南下半部分描述的
-> `codeindex parse`（逐文件 JSON）→ `loomgraph inject` 集成范式是**早期方案**。
-> 当前的**正式数据接缝是 `graph-export` NDJSON 契约**（GH #102 / ADR-007）：
->
-> ```bash
-> codeindex graph-export --root . -o graph-export.ndjson   # codeindex 侧
-> loomgraph import-export graph-export.ndjson              # loomgraph 侧
-> ```
->
-> 契约规格见 [graph-export.md](graph-export.md)。此外 LightRAG 已退役 —— LoomGraph
-> 本地化后用内嵌 **SQLite + sqlite-vec** 自带图存储 + 向量检索，不再需要外部存储服务。
-> 下方的 parse JSON schema 仍然准确、`parse` 命令仍可用，但新集成应走 graph-export。
+**目标读者**: LoomGraph 项目组开发者，以及任何想把 codeindex 的解析结果喂给下游知识图谱 / 检索系统的人。
 
 ---
 
-## 🎯 架构设计：松耦合 CLI 方案
-
-### 架构概览（两仓模型）
+## 🎯 架构：两仓、单向、进程解耦
 
 ```
-codeindex (CLI)         →   LoomGraph (CLI / MCP)
-   解析层（无状态）           存储 + 查询（SQLite + sqlite-vec，自包含）
-   graph-export NDJSON       import-export → 知识图谱 + 向量检索
+codeindex (CLI, 无状态)          →          LoomGraph (CLI / MCP, 有状态)
+   AST 解析 → 结构切片                          SQLite + sqlite-vec
+   graph-export NDJSON  ────────────────▶      import-export → 知识图谱 + 向量检索 + MCP
 ```
 
-### 为什么选择 CLI 而不是 Python API？
+- **codeindex — 解析层（无状态）**：tree-sitter 抽取 symbol / call / inheritance，产出
+  **write-once 制品**。它不持有任何持久化状态——没有 `.db`、没有增量同步、没有向量索引
+  （[ADR-007](../architecture/adr/007-codeindex-stateless-graph-ownership.md)）。
+- **LoomGraph — 存储 + 查询层（有状态）**：用内嵌 **SQLite + sqlite-vec** 自建知识图谱
+  和向量检索，提供 query CLI 与 MCP server。它是自包含的，**不再依赖 LightRAG 或任何外部
+  RAG 框架 / PostgreSQL**。
+- 两仓之间**唯一的数据接缝**是 codeindex 的输出制品。codeindex 不 import loomgraph，
+  loomgraph 通过子进程调用 codeindex CLI（进程隔离、独立升级、错误不跨进程传播）。
 
-| 维度 | CLI 调用（推荐） | Python API 调用 |
-|------|------------------|----------------|
-| **耦合度** | ✅ 松耦合 | ❌ 紧耦合 |
-| **依赖管理** | ✅ 独立安装 | ❌ 必须同环境 |
-| **版本升级** | ✅ 独立升级 | ❌ 需要同步升级 |
-| **环境隔离** | ✅ 进程隔离 | ❌ 共享 Python 环境 |
-| **跨语言支持** | ✅ 任何语言可调用 | ❌ 仅限 Python |
-| **错误隔离** | ✅ 进程崩溃不影响调用方 | ❌ 异常可能传播 |
+### 为什么是 CLI 子进程而非 Python API
 
-**结论**: CLI 方案提供更好的架构独立性和可维护性。
+松耦合。两仓独立安装、独立发版、进程隔离；codeindex 崩溃不会拖垮 loomgraph；任何语言都能调
+CLI。代价是一次子进程 + JSON/NDJSON 序列化开销，对"解析整仓"这种粒度可以忽略。
 
 ---
 
-## 📦 快速开始
-
-### 1. 安装 codeindex
+## 📦 安装
 
 ```bash
-# 推荐：使用 pipx 隔离安装
-pipx install ai-codeindex[all]
+pipx install "ai-codeindex[all]"   # 推荐，隔离安装（含全部语言 parser）
+# 或
+pip install "ai-codeindex[all]"
 
-# 或者：pip 安装
-pip install ai-codeindex[all]
-
-# 验证安装
 codeindex --version
-# 输出: codeindex, version 0.13.0
 ```
 
-### 2. 基本用法
+> ⚠️ PyPI 包名是 **`ai-codeindex`**（CLI 命令是 `codeindex`）。不要用 `matrix-codeindex` /
+> `codeindex` 之类的包名安装。
 
-```bash
-# 解析单个 Python 文件
-codeindex parse src/myfile.py
-
-# 解析 Java 文件
-codeindex parse Service.java
-
-# 解析 PHP 文件
-codeindex parse Controller.php
-```
-
-### 3. 验证功能
-
-```bash
-# 检查 parse 命令是否可用
-codeindex parse --help
-
-# 测试解析（使用 codeindex 自己的代码）
-codeindex parse $(python -c "import codeindex; print(codeindex.__file__.replace('__init__.py', 'parser.py'))")
-```
+**支持的语言**（7）：Python (.py) / PHP (.php .phtml) / Java (.java) /
+TypeScript (.ts .tsx) / JavaScript (.js .jsx) / Swift (.swift) / Objective-C (.m .h)。
 
 ---
 
-## 📋 JSON 输出格式详解
+## 🔌 三条集成路径
 
-### 完整输出结构
+按"整仓图谱 → 单文件程序化"排序。**新集成优先用路径 A。**
+
+### 路径 A（推荐）：`graph-export` NDJSON 契约
+
+codeindex 对整棵树做一次干净解析，产出 **write-once** 的 NDJSON 图谱制品；loomgraph 用
+`import-export` 消费。这是当前的**正式数据契约**（ADR-007）。
+
+```bash
+# codeindex 侧：产出制品（自带一次全树解析，每个文件恰好解析一次，与 scan-all / README 渲染完全解耦）
+codeindex graph-export --root . -o graph-export.ndjson
+codeindex graph-export --root . -o -            # 输出到 stdout
+
+# loomgraph 侧：导入到 workspace
+loomgraph import-export graph-export.ndjson
+loomgraph import-export graph-export.ndjson --dry-run   # 只校验 + 打印摘要，不落库
+loomgraph import-export graph-export.ndjson -w myproj --clear   # 指定 workspace 并清空重建
+```
+
+制品结构（NDJSON：第 1 行 `meta`，随后 `entity`，随后 `edge`）：
+
+```jsonc
+{"type":"meta","schema_version":0,"generator":"codeindex","provenance_completeness":"ast-only: ..."}
+{"type":"entity","id":"app.service.AuthService","entity_type":"class","source_id":"app/service.py:8","description":"Authenticates users.","provenance":"ast"}
+{"type":"edge","kind":"CALLS","src":"app.service.AuthService.login","dst":"app.service.AuthService.authenticate","resolution_qualifier":"resolved","source_id":"app/service.py:15"}
+```
+
+**完整字段规格、命名约定、消费者契约（两条必读 caveat）见
+[graph-export.md](graph-export.md)。** 集成前请务必读这两条，否则会得出错误结论：
+
+1. **`resolution_qualifier`** —— 永远不要把 `unresolved` / `ambiguous` 边当作已确认的关系。
+   解析器只产出 file-local 名字，export 做唯一一次跨文件解析；高 unresolved 比例是正常的
+   （真实代码里大量调用指向 stdlib / 三方 / AST 无法静态解析的方法，实测 loomgraph 自身
+   round-trip ≈59% unresolved）。`import-export` 会**保留 `resolved`/`ambiguous`、跳过
+   `unresolved`**（不插占位节点，否则会在 topology 分析里造出误导性 hub）。
+2. **`provenance_completeness`** —— 抽取是 AST-only。动态派发、反射 / 元类、装饰器 wiring
+   **不被捕获**。**边的缺失意味着"静态不可解析"，不等于"没有"。**
+
+**这是一个结构切片，不是完整图谱索引**：只含真实代码符号（class/function/method）及其
+CALLS/INHERITS 边，不含 file/module 容器节点和外部/stdlib stub —— 这些由消费者在 ingest 时
+围绕切片自行合成（ADR-007）。
+
+### 路径 B（便捷）：`loomgraph index <repo>` 一步式
+
+loomgraph 提供一个一步式命令，内部自动调用 codeindex 完成"扫描 → embedding → 建图"：
+
+```bash
+loomgraph index /path/to/repo          # 一条命令建好可查询的 workspace
+loomgraph index /path/to/repo -w myproj
+```
+
+适合"我只想快速把一个仓库变成可查询的图谱"。前提是 `codeindex` 已在 PATH 中。
+
+> 现状说明：`loomgraph index` 目前内部走的是较早的 `codeindex scan --output json` 路径，
+> 尚未迁移到路径 A 的 graph-export 契约。二者产出的 workspace 内容可能有差异；需要契约级
+> 保证（qualifier / provenance 元数据）时用路径 A。
+
+### 路径 C（低层）：`codeindex parse <file>` 单文件 JSON
+
+程序化、逐文件的解析 API，适合流式 / 增量 / 只处理个别文件的场景。**不做跨文件解析**——
+输出的是 file-local 结果。
+
+```bash
+codeindex parse src/auth/user.py       # 固定输出 JSON 到 stdout
+```
+
+输出结构：
 
 ```json
 {
@@ -94,584 +121,90 @@ codeindex parse $(python -c "import codeindex; print(codeindex.__file__.replace(
   "language": "python",
   "symbols": [
     {
-      "name": "User",
-      "kind": "class",
-      "signature": "class User(BaseModel):",
-      "docstring": "User authentication model with JWT support",
-      "line_start": 10,
-      "line_end": 50,
-      "annotations": [
-        {
-          "name": "dataclass",
-          "arguments": {}
-        }
-      ]
-    },
-    {
       "name": "User.authenticate",
       "kind": "method",
       "signature": "def authenticate(self, password: str) -> bool:",
       "docstring": "Authenticate user with password",
       "line_start": 25,
       "line_end": 30,
-      "annotations": []
+      "annotations": [{"name": "override", "arguments": {}}]
     }
   ],
   "imports": [
-    {
-      "module": "typing",
-      "names": ["Dict", "Optional"],
-      "is_from": true,
-      "alias": null
-    },
-    {
-      "module": "pydantic",
-      "names": [],
-      "is_from": false,
-      "alias": "pd"
-    }
+    {"module": "typing", "names": ["Dict", "Optional"], "is_from": true, "alias": null}
   ],
   "namespace": "",
   "error": null
 }
 ```
 
-### 字段说明
+| 字段 | 说明 |
+|------|------|
+| `file_path` / `language` | 文件路径 / 语言标识 |
+| `symbols[]` | `name`(方法带类名如 `User.authenticate`) / `kind`(class·function·method) / `signature` / `docstring` / `line_start` / `line_end` / `annotations[]` |
+| `imports[]` | `module` / `names[]` / `is_from` / `alias` |
+| `namespace` | 命名空间/包名（PHP/Java；Python 为空串） |
+| `error` | 错误信息或 `null`。**部分解析**时 `error` 为 `null` 但结果可能不完整——见下 |
 
-#### 顶层字段
+**Exit code**：`0` 成功；`1` 文件不存在 / 非文件 / 无权限；`2` 不支持的文件类型；
+`3` 解析失败（`stdout` 仍是带 `error` 字段的 JSON，可能含部分符号）。
 
-| 字段 | 类型 | 说明 | 示例 |
-|------|------|------|------|
-| `file_path` | string | 文件路径（相对或绝对） | `"src/auth/user.py"` |
-| `language` | string | 语言标识 | `"python"`, `"php"`, `"java"` |
-| `symbols` | array | 符号列表（类/函数/方法） | `[{...}, {...}]` |
-| `imports` | array | 导入语句列表 | `[{...}]` |
-| `namespace` | string | 命名空间/包名（PHP/Java） | `"com.example.service"` |
-| `error` | string\|null | 错误信息（如果有） | `null` 或 `"Parse error: ..."` |
+**部分解析恢复**：单个语法错误不会清零整个文件的符号（GH #95）。解析器会尽量返回可恢复的符号；
+消费端应始终 `result.get("symbols", [])` 兜底，不要因 `error` 非空就丢弃全部结果。
 
-#### Symbol 对象
-
-| 字段 | 类型 | 说明 | 示例 |
-|------|------|------|------|
-| `name` | string | 符号名称 | `"User"`, `"User.authenticate"` |
-| `kind` | string | 符号类型 | `"class"`, `"function"`, `"method"` |
-| `signature` | string | 完整签名 | `"def authenticate(self, password: str) -> bool:"` |
-| `docstring` | string | 文档字符串 | `"Authenticate user with password"` |
-| `line_start` | int | 起始行号（1-based） | `10` |
-| `line_end` | int | 结束行号（1-based） | `50` |
-| `annotations` | array | 注解/装饰器列表 | `[{"name": "Service", "arguments": {}}]` |
-
-#### Import 对象
-
-| 字段 | 类型 | 说明 | 示例 |
-|------|------|------|------|
-| `module` | string | 模块名 | `"typing"`, `"numpy"` |
-| `names` | array | 导入的名称列表 | `["Dict", "Optional"]` |
-| `is_from` | bool | 是否是 from 导入 | `true` (from X import Y), `false` (import X) |
-| `alias` | string\|null | 别名（如果有） | `"np"` (import numpy as np) |
-
----
-
-## 🔌 LoomGraph 集成方案
-
-### 方案 A: Python subprocess 调用（推荐）
+最小 Python 封装：
 
 ```python
-import json
-import subprocess
-from pathlib import Path
-from typing import Dict, Any, Optional
-
-class CodeIndexParser:
-    """codeindex CLI wrapper for LoomGraph"""
-
-    def __init__(self, codeindex_bin: str = "codeindex"):
-        """
-        Args:
-            codeindex_bin: Path to codeindex executable (default: "codeindex" in PATH)
-        """
-        self.codeindex_bin = codeindex_bin
-        self._verify_installation()
-
-    def _verify_installation(self):
-        """Verify codeindex is installed and accessible"""
-        try:
-            result = subprocess.run(
-                [self.codeindex_bin, "--version"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5
-            )
-            print(f"✓ codeindex available: {result.stdout.strip()}")
-        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
-            raise RuntimeError(
-                f"codeindex not found or not working. "
-                f"Please install: pip install ai-codeindex[all]"
-            ) from e
-
-    def parse_file(self, file_path: Path) -> Dict[str, Any]:
-        """
-        Parse a single source file using codeindex CLI.
-
-        Args:
-            file_path: Path to the source file
-
-        Returns:
-            Parsed result as dict with keys:
-            - file_path: str
-            - language: str
-            - symbols: List[Dict]
-            - imports: List[Dict]
-            - namespace: str
-            - error: str | None
-
-        Raises:
-            FileNotFoundError: If file doesn't exist (exit code 1)
-            ValueError: If file type is unsupported (exit code 2)
-            RuntimeError: If parsing failed (exit code 3)
-        """
-        try:
-            result = subprocess.run(
-                [self.codeindex_bin, "parse", str(file_path)],
-                capture_output=True,
-                text=True,
-                timeout=30  # 30s timeout for large files
-            )
-
-            # Parse JSON output
-            data = json.loads(result.stdout)
-
-            # Handle exit codes
-            if result.returncode == 1:
-                raise FileNotFoundError(f"File not found or permission denied: {file_path}")
-            elif result.returncode == 2:
-                raise ValueError(f"Unsupported file type: {file_path}")
-            elif result.returncode == 3:
-                # Parse error, but data might be partial
-                print(f"Warning: Parse error for {file_path}: {data.get('error')}")
-
-            return data
-
-        except json.JSONDecodeError as e:
-            raise RuntimeError(f"Invalid JSON output from codeindex: {e}") from e
-        except subprocess.TimeoutExpired:
-            raise RuntimeError(f"Parsing timeout (>30s) for {file_path}")
-
-
-# 使用示例
-if __name__ == "__main__":
-    parser = CodeIndexParser()
-
-    # 解析单个文件
-    result = parser.parse_file(Path("src/user.py"))
-
-    print(f"Language: {result['language']}")
-    print(f"Symbols: {len(result['symbols'])}")
-    print(f"Imports: {len(result['imports'])}")
-
-    # 提取类名列表
-    classes = [s['name'] for s in result['symbols'] if s['kind'] == 'class']
-    print(f"Classes: {classes}")
-```
-
-### 方案 B: Node.js/TypeScript 调用
-
-```typescript
-import { spawn } from 'child_process';
-import { promisify } from 'util';
-import * as fs from 'fs/promises';
-
-interface ParseResult {
-  file_path: string;
-  language: string;
-  symbols: Symbol[];
-  imports: Import[];
-  namespace: string;
-  error: string | null;
-}
-
-interface Symbol {
-  name: string;
-  kind: 'class' | 'function' | 'method';
-  signature: string;
-  docstring: string;
-  line_start: number;
-  line_end: number;
-  annotations: Annotation[];
-}
-
-interface Import {
-  module: string;
-  names: string[];
-  is_from: boolean;
-  alias: string | null;
-}
-
-interface Annotation {
-  name: string;
-  arguments: Record<string, string>;
-}
-
-class CodeIndexParser {
-  constructor(private codeindexBin: string = 'codeindex') {}
-
-  async parseFile(filePath: string): Promise<ParseResult> {
-    return new Promise((resolve, reject) => {
-      const process = spawn(this.codeindexBin, ['parse', filePath]);
-
-      let stdout = '';
-      let stderr = '';
-
-      process.stdout.on('data', (data) => {
-        stdout += data.toString();
-      });
-
-      process.stderr.on('data', (data) => {
-        stderr += data.toString();
-      });
-
-      process.on('close', (code) => {
-        if (code === 1) {
-          reject(new Error(`File not found: ${filePath}`));
-        } else if (code === 2) {
-          reject(new Error(`Unsupported file type: ${filePath}`));
-        } else if (code === 3) {
-          console.warn(`Parse error for ${filePath}: ${stderr}`);
-        }
-
-        try {
-          const result = JSON.parse(stdout) as ParseResult;
-          resolve(result);
-        } catch (e) {
-          reject(new Error(`Invalid JSON output: ${e}`));
-        }
-      });
-
-      process.on('error', (err) => {
-        reject(new Error(`Failed to spawn codeindex: ${err.message}`));
-      });
-    });
-  }
-}
-
-// 使用示例
-(async () => {
-  const parser = new CodeIndexParser();
-  const result = await parser.parseFile('src/user.py');
-
-  console.log(`Language: ${result.language}`);
-  console.log(`Symbols: ${result.symbols.length}`);
-  console.log(`Classes: ${result.symbols.filter(s => s.kind === 'class').map(s => s.name)}`);
-})();
-```
-
----
-
-## 🚀 批量处理模式
-
-### 场景 1: 批量解析目录
-
-```python
-from pathlib import Path
-from typing import List, Dict
-import concurrent.futures
-
-def parse_directory(
-    dir_path: Path,
-    pattern: str = "*.py",
-    max_workers: int = 4
-) -> List[Dict]:
-    """批量解析目录中的所有文件"""
-    parser = CodeIndexParser()
-    files = list(dir_path.rglob(pattern))
-
-    results = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_file = {
-            executor.submit(parser.parse_file, f): f
-            for f in files
-        }
-
-        for future in concurrent.futures.as_completed(future_to_file):
-            file = future_to_file[future]
-            try:
-                result = future.result()
-                results.append(result)
-                print(f"✓ Parsed {file}")
-            except Exception as e:
-                print(f"✗ Failed to parse {file}: {e}")
-
-    return results
-
-# 使用
-results = parse_directory(Path("src/"), pattern="*.py", max_workers=8)
-print(f"Total files parsed: {len(results)}")
-```
-
-### 场景 2: 流式处理（Shell 管道）
-
-```bash
-#!/bin/bash
-# 批量解析并合并为单个 JSON 数组
-
-find src/ -name "*.py" | while read file; do
-  codeindex parse "$file"
-done | jq -s '.'
-```
-
----
-
-## 🛡️ 错误处理最佳实践
-
-### 1. Exit Code 处理
-
-```python
-def parse_with_fallback(file_path: Path) -> Optional[Dict]:
-    """解析文件，失败时返回 None 而不是抛异常"""
-    try:
-        return parser.parse_file(file_path)
-    except FileNotFoundError:
-        print(f"Skipping missing file: {file_path}")
-        return None
-    except ValueError:
-        print(f"Skipping unsupported file: {file_path}")
-        return None
-    except RuntimeError as e:
-        print(f"Parse error for {file_path}: {e}")
-        return None
-```
-
-### 2. 部分解析结果处理
-
-```python
-def extract_symbols_safely(result: Dict) -> List[Dict]:
-    """提取符号，即使有解析错误"""
-    if result.get('error'):
-        print(f"Warning: Partial parse result due to: {result['error']}")
-
-    # 即使有错误，symbols 列表可能仍然包含部分结果
-    return result.get('symbols', [])
-```
-
-### 3. 超时处理
-
-```python
-import signal
-from contextlib import contextmanager
-
-@contextmanager
-def timeout(seconds: int):
-    """超时上下文管理器"""
-    def handler(signum, frame):
-        raise TimeoutError(f"Operation timed out after {seconds}s")
-
-    signal.signal(signal.SIGALRM, handler)
-    signal.alarm(seconds)
-    try:
-        yield
-    finally:
-        signal.alarm(0)
-
-# 使用
-try:
-    with timeout(60):
-        result = parser.parse_file(large_file)
-except TimeoutError:
-    print("File too large, skipping...")
-```
-
----
-
-## 📊 性能考虑
-
-### 基准性能
-
-| 文件大小 | 解析时间 | 符号数 |
-|---------|---------|--------|
-| <100 行 | <0.05s | <10 |
-| 100-1000 行 | 0.05-0.15s | 10-50 |
-| 1000-5000 行 | 0.15-0.5s | 50-200 |
-| >5000 行 | 0.5-2s | 200+ |
-
-### 优化建议
-
-1. **并行处理**: 使用 ThreadPoolExecutor 并行解析多个文件
-2. **批量过滤**: 在调用前过滤不支持的文件类型
-3. **缓存结果**: 对于不常变化的文件，缓存解析结果
-4. **增量解析**: 只解析修改过的文件
-
-```python
-import hashlib
+import json, subprocess
 from pathlib import Path
 
-class CachedParser:
-    def __init__(self, cache_dir: Path = Path(".cache")):
-        self.parser = CodeIndexParser()
-        self.cache_dir = cache_dir
-        self.cache_dir.mkdir(exist_ok=True)
-
-    def _get_cache_key(self, file_path: Path) -> str:
-        """计算文件的缓存键（基于内容哈希）"""
-        content = file_path.read_bytes()
-        return hashlib.sha256(content).hexdigest()
-
-    def parse_file_cached(self, file_path: Path) -> Dict:
-        """带缓存的解析"""
-        cache_key = self._get_cache_key(file_path)
-        cache_file = self.cache_dir / f"{cache_key}.json"
-
-        if cache_file.exists():
-            return json.loads(cache_file.read_text())
-
-        result = self.parser.parse_file(file_path)
-        cache_file.write_text(json.dumps(result))
-        return result
+def parse_file(path: Path) -> dict | None:
+    r = subprocess.run(["codeindex", "parse", str(path)],
+                       capture_output=True, text=True, timeout=30)
+    if r.returncode in (1, 2):        # 缺失 / 不支持 → 跳过
+        return None
+    return json.loads(r.stdout)       # returncode 0 或 3(部分/失败) 都返回可用 JSON
 ```
 
 ---
 
-## 🔄 版本兼容性
+## 🔄 版本兼容
 
-### 检查 codeindex 版本
+- **`parse` JSON（路径 C）**：字段只增不减，向后兼容；破坏性变更只随 MAJOR 版本发生。
+- **`graph-export` NDJSON（路径 A）**：**实验中（`schema_version: 0`）**，在 0 版本期间字段/
+  格式可能无 deprecation 直接变更。消费端应读 `meta.schema_version` 并对未知版本告警。
 
-```python
-import re
-
-def check_codeindex_version(min_version: str = "0.13.0") -> bool:
-    """检查 codeindex 版本是否满足最低要求"""
-    result = subprocess.run(
-        ["codeindex", "--version"],
-        capture_output=True,
-        text=True
-    )
-
-    # 输出格式: "codeindex, version 0.13.0"
-    match = re.search(r'version (\d+\.\d+\.\d+)', result.stdout)
-    if not match:
-        raise RuntimeError("Cannot determine codeindex version")
-
-    current = tuple(map(int, match.group(1).split('.')))
-    required = tuple(map(int, min_version.split('.')))
-
-    return current >= required
-
-# 使用
-if not check_codeindex_version("0.13.0"):
-    raise RuntimeError("codeindex >= 0.13.0 required for parse command")
-```
-
-### JSON 格式稳定性承诺
-
-codeindex 保证：
-- ✅ **字段只增不减**: 新版本可能添加字段，但不会删除现有字段
-- ✅ **向后兼容**: v0.13.0+ 的 JSON 格式向后兼容
-- ✅ **语义化版本**: MAJOR 版本变更才会有破坏性变化
-
----
-
-## 🧪 测试建议
-
-### 单元测试示例
-
-```python
-import unittest
-from unittest.mock import patch, MagicMock
-
-class TestCodeIndexIntegration(unittest.TestCase):
-
-    def setUp(self):
-        self.parser = CodeIndexParser()
-
-    def test_parse_python_file(self):
-        """测试解析 Python 文件"""
-        result = self.parser.parse_file(Path("tests/fixtures/simple.py"))
-
-        self.assertEqual(result['language'], 'python')
-        self.assertGreater(len(result['symbols']), 0)
-        self.assertIsNone(result['error'])
-
-    def test_file_not_found(self):
-        """测试文件不存在错误"""
-        with self.assertRaises(FileNotFoundError):
-            self.parser.parse_file(Path("nonexistent.py"))
-
-    def test_unsupported_file_type(self):
-        """测试不支持的文件类型"""
-        with self.assertRaises(ValueError):
-            self.parser.parse_file(Path("README.md"))
-
-    @patch('subprocess.run')
-    def test_timeout_handling(self, mock_run):
-        """测试超时处理"""
-        mock_run.side_effect = subprocess.TimeoutExpired("codeindex", 30)
-
-        with self.assertRaises(RuntimeError) as cm:
-            self.parser.parse_file(Path("large_file.py"))
-
-        self.assertIn("timeout", str(cm.exception).lower())
-```
+版本检查直接解析 `codeindex --version` 输出即可（格式 `codeindex, version X.Y.Z`）。
 
 ---
 
 ## 📚 FAQ
 
-### Q1: codeindex parse 和 scan 的区别？
+**Q: 路径 A / B / C 怎么选？**
+整仓建图谱、要契约保证 → **A**（graph-export）。只想一条命令跑通、不在意底层 → **B**
+（`loomgraph index`）。流式 / 增量 / 逐文件程序化处理 → **C**（`parse`）。
 
-**A**:
-- `parse`: 解析**单个文件**，输出 JSON，用于程序化集成
-- `scan`: 扫描**目录**，生成 README_AI.md 文档，用于人类阅读
+**Q: `graph-export` 和 `scan` 有什么区别？**
+`scan` / `scan-all` 面向**人**，生成 `README_AI.md` 导航文档。`graph-export` 面向**机器**，
+产出结构化图谱制品，且做一次干净全树解析（每文件一次），**不触碰 README_AI.md**。
 
-### Q2: 为什么不直接使用 scan --output json？
+**Q: 为什么 unresolved 边这么多？正常吗？**
+正常。真实代码里大量调用指向 stdlib / 三方 / 动态派发，AST 静态解析不了。见路径 A 的两条
+caveat 与 [graph-export.md](graph-export.md)。
 
-**A**:
-- `scan` 针对目录，包含多个文件的聚合数据
-- `parse` 针对单个文件，更轻量，更适合逐文件处理
-- `parse` 启动更快（无需配置文件）
+**Q: LightRAG / PostgreSQL 还需要吗？**
+不需要。LoomGraph 本地化后用内嵌 SQLite + sqlite-vec 取代，"no RAG framework needed"。
 
-### Q3: 支持哪些语言？
-
-**A**:
-- Python (.py)
-- PHP (.php, .phtml)
-- Java (.java)
-
-### Q4: 如何处理大文件（>10000 行）？
-
-**A**:
-- codeindex 可以处理大文件，但可能需要 2-5 秒
-- 建议设置合理的超时时间（30-60 秒）
-- 考虑使用缓存策略避免重复解析
-
-### Q5: 可以在 Docker 容器中使用吗？
-
-**A**:
-可以！示例 Dockerfile:
-```dockerfile
-FROM python:3.10-slim
-RUN pip install ai-codeindex[all]
-CMD ["codeindex", "parse", "/input/file.py"]
-```
+**Q: 能在 Docker / CI 里用吗？**
+可以。`pip install "ai-codeindex[all]"` 后 `codeindex graph-export` / `parse` 都是无状态的
+纯 CLI 调用，天然适合 CI。
 
 ---
 
 ## 🔗 相关资源
 
+- **graph-export 契约规格**: [graph-export.md](graph-export.md)
+- **无状态设计决策**: [ADR-007](../architecture/adr/007-codeindex-stateless-graph-ownership.md)
 - **codeindex GitHub**: https://github.com/dreamlx/codeindex
-- **PyPI Package**: https://pypi.org/project/ai-codeindex/
-- **示例脚本**: `examples/parse_integration_example.sh`
-
----
-
-## 📞 支持与反馈
-
-遇到问题？
-1. 查看 codeindex 日志: `codeindex parse file.py --verbose` (如果实现)
-2. 提交 Issue: https://github.com/dreamlx/codeindex/issues
-3. 查看 CHANGELOG: `docs/CHANGELOG.md`
-
----
-
-**最后更新**: 2026-02-07
-**适用版本**: codeindex >= 0.13.0
-**维护者**: codeindex team
+- **PyPI**: https://pypi.org/project/ai-codeindex/
+- **Issue**: https://github.com/dreamlx/codeindex/issues

--- a/docs/guides/loomgraph-integration.md
+++ b/docs/guides/loomgraph-integration.md
@@ -2,17 +2,30 @@
 
 **目标读者**: LoomGraph 项目组开发者
 **版本**: codeindex v0.13.0+
-**更新日期**: 2026-02-07
+
+> ⚠️ **架构已更新（2026-07，两仓模型）**：本指南下半部分描述的
+> `codeindex parse`（逐文件 JSON）→ `loomgraph inject` 集成范式是**早期方案**。
+> 当前的**正式数据接缝是 `graph-export` NDJSON 契约**（GH #102 / ADR-007）：
+>
+> ```bash
+> codeindex graph-export --root . -o graph-export.ndjson   # codeindex 侧
+> loomgraph import-export graph-export.ndjson              # loomgraph 侧
+> ```
+>
+> 契约规格见 [graph-export.md](graph-export.md)。此外 LightRAG 已退役 —— LoomGraph
+> 本地化后用内嵌 **SQLite + sqlite-vec** 自带图存储 + 向量检索，不再需要外部存储服务。
+> 下方的 parse JSON schema 仍然准确、`parse` 命令仍可用，但新集成应走 graph-export。
 
 ---
 
 ## 🎯 架构设计：松耦合 CLI 方案
 
-### 架构概览
+### 架构概览（两仓模型）
 
 ```
-codeindex (CLI)  →  LoomGraph (CLI)  →  LightRAG (API)
-   独立工具          调度编排            存储服务
+codeindex (CLI)         →   LoomGraph (CLI / MCP)
+   解析层（无状态）           存储 + 查询（SQLite + sqlite-vec，自包含）
+   graph-export NDJSON       import-export → 知识图谱 + 向量检索
 ```
 
 ### 为什么选择 CLI 而不是 Python API？


### PR DESCRIPTION
Closes #106.

Syncs the docs to the current two-repo reality: LoomGraph's local refactor
replaced LightRAG with an embedded SQLite + sqlite-vec store ("no RAG framework
needed"), so the old three-repo model (codeindex sees / LoomGraph thinks /
LightRAG remembers) is stale.

## Commits

**1. Two-repo model sync** (`389608b`)
- `CLAUDE.md`: Three-Repo → Two-Repo table; fixed stale `/opensource/` paths
- `README.md` + `README_zh.md`: compact flow + enterprise diagram
- `loomgraph-integration.md`: banner pointing to graph-export as the canonical seam

**2. Deep-rewrite guide + add ADR-007** (`7d77fa0`)
- `loomgraph-integration.md` (665 → 210 lines): leads with the graph-export NDJSON
  contract (path A, ADR-007); documents all three integration surfaces
  (A graph-export→import-export, B one-step `loomgraph index`, C per-file `parse`);
  kept the still-accurate parse schema/exit codes/partial-parse note as path C;
  dropped the inject-based flow + subprocess boilerplate; fixed stale facts
  (7 languages, correct `ai-codeindex` package name, removed dated stamps).
- **Added ADR-007** (codeindex stateless / persistent graph belongs to loomgraph).
  It was referenced by the already-shipped `graph-export.md` and this guide but
  had never been committed — a dead link. Reconstructed from the v0.27.0 decision
  (write-once emitter, export≠render-flip, structural slice only).

## Not touched
Dated historical artifacts (RELEASE_NOTES, reports/, evaluation/) left as-is per
the docs policy (point-in-time records don't get retro-edited).

## Related (LoomGraph-side, filed separately)
Found while reading loomgraph source for the rewrite — tracked in dreamlx/LoomGraph
issues: `loomgraph index` uses the wrong package name in its error and still runs
the legacy scan-JSON path instead of graph-export.