### PR TITLE
fix(test): gitignore README_AI under char_graphbuffer fixture (#135)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ htmlcov/
 # Project specific
 .codeindex.yaml
 
+# GH #135: scan-all (root config includes tests/) generates README_AI.md inside
+# test fixtures. The #101 characterization fixture must stay byte-identical
+# (baseline goldens), so committing a generated README there drifts CI. Ignore
+# ONLY char_graphbuffer — other fixture READMEs (cli_parse/, graph_export/) are
+# legit tracked navigation assets and must stay committable.
+tests/fixtures/char_graphbuffer/**/README_AI.md
+
 # Serena MCP rewrites this on every project activation — keeps memories tracked.
 .serena/project.yml
 .serena/project.local.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **scan-all can no longer pollute the characterization fixture** (GH #135).
+  `codeindex scan-all` (root config `include: tests/`) walked test fixtures and
+  generated `README_AI.md` inside `tests/fixtures/char_graphbuffer/` — the #101
+  characterization fixture that must stay byte-identical. The generated files
+  were not gitignored, so a `git add -A` committed them, drifted the baseline
+  goldens, and broke `test_structural_readmes` /
+  `test_enrich_prompts_and_frozen_ai_readmes` on CI. `.gitignore` now blocks
+  `tests/fixtures/char_graphbuffer/**/README_AI.md` specifically (other fixture
+  READMEs — `cli_parse/`, `graph_export/` — stay committable; they are legit
+  tracked navigation assets).
 - **graph-export Python constructor calls now resolve to the class entity**
   (GH #132). The Python parser tags every `CONSTRUCTOR` call's callee as
   `Class.__init__` (`parsers/python/calls.py`); `_resolve` then keyed on the


### PR DESCRIPTION
## Summary

Root-fix for #135 — the scan-all fixture-pollution landmine that broke CI in
PR #134.

`codeindex scan-all` (root config `include: tests/`) walks test fixtures and
generated `README_AI.md` inside `tests/fixtures/char_graphbuffer/` — the #101
characterization fixture that must stay byte-identical. The generated files
weren't gitignored, so `git add -A` committed them → baseline goldens drifted →
`test_structural_readmes` / `test_enrich_prompts_and_frozen_ai_readmes` red on
CI (local stayed green because the polluted files matched what scan-all
produced — the classic "works on my disk" gap).

## Fix

`.gitignore` now blocks `tests/fixtures/char_graphbuffer/**/README_AI.md`
**specifically**. Scoped — other fixture READMEs (`cli_parse/`,
`graph_export/`) are legit tracked navigation assets and stay committable.

## Verification

- `char_graphbuffer/**/README_AI.md` → now ignored ✓
- `cli_parse/README_AI.md`, `graph_export/project/README_AI.md` → still
  trackable ✓ (not over-broad)
- Simulated scan-all regen of the fixture README → no longer leaks into
  `git status` (so `git add -A` can't re-commit it) ✓
- Full suite 1767 passed (incl. all 4 characterization tests); post-commit
  scan-all hook ran clean — no char_graphbuffer pollution

## Why not the other options

- **Exclude from root config**: root `.codeindex.yaml` is gitignored, so a
  local exclude never reaches CI.
- **`.noindex` sentinel**: needs scan-all logic changes, out of scope.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)