### PR TITLE
fix(graph-export): resolve TS barrel `from "."` + named re-export (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   monorepo multi-tsconfig (out of scope). JSONC `//` and `/* */` comments are
   stripped without adding a dependency (json5/commentjson not in the wheel).
 
+- **graph-export now resolves TS barrel `from "."` and propagates named
+  re-exports** (GH #140). `import { X } from "."` (which means "current
+  directory's `index.ts`") was routed through the Python PEP 328 branch —
+  which correctly yields the directory id, but `_resolve_module` had no TS
+  `.index` fallback (only Python `.__init__`), so the barrel module never
+  resolved → zero IMPORTS/REFERENCES edges through barrels. Additionally,
+  named re-exports (`export { X } from "./mod"` in a barrel) were
+  indistinguishable from regular imports, so an import reaching a barrel
+  could not follow the re-export to the real definition module (the barrel
+  doesn't define `X` locally). `_check_fallbacks` now has a TS `.index`
+  fallback (after `.__init__`, so mixed Python+TS dirs stay Python); `Import`
+  carries an `is_reexport` flag set by the TS parser's `_parse_export_as_import`;
+  and Pass 4 follows re-export chains (barrel → source module, with chained
+  barrels and cycle-breaking via a `visited` set) to the real definition entity.
+  Wildcard `export * from` remains out of scope (documented skip — needs
+  cross-file member tracking). Parallel to #139; the two share the same silent
+  drop point (Pass 4) but are mechanically orthogonal.
+
 ## [0.33.1] - 2026-07-11
 
 ### Fixed

--- a/src/codeindex/graph_export.py
+++ b/src/codeindex/graph_export.py
@@ -292,10 +292,10 @@ def _check_fallbacks(target: str, module_set: set[str]) -> str | None:
     """Shared resolution chain for a dotted module-id ``target``.
 
     Tries, in order: exact scan-tree match → src-layout prefix (GH #118/#133)
-    → Python ``__init__`` barrel (GH #133). Returns the resolved module id, or
-    ``None``. Shared by the main ``_resolve_module`` path and the #139 alias
-    branch so both follow the same fallback order — adding a new fallback here
-    fixes both at once.
+    → Python ``__init__`` barrel (GH #133) → TS ``index`` barrel (GH #140).
+    Returns the resolved module id, or ``None``. Shared by the main
+    ``_resolve_module`` path and the #139 alias branch so both follow the same
+    fallback order — adding a new fallback here fixes both at once.
     """
     if target in module_set:
         return target
@@ -305,9 +305,15 @@ def _check_fallbacks(target: str, module_set: set[str]) -> str | None:
             return candidate
     # Package-level import (``from . import X`` / ``from pkg import Y``): the
     # target is a package/dir name, but the scan tree stores its init module.
-    # Python __init__.py → ``pkg.__init__`` (GH #133).
+    # Python __init__.py → ``pkg.__init__`` (GH #133); checked before TS index
+    # so a (pathological) mixed Python+TS dir resolves to the Python package.
     if target + ".__init__" in module_set:
         return target + ".__init__"
+    # TS/JS barrel: ``from "."`` / ``from "./sub"`` targets a directory whose
+    # ``index.ts`` is the module. The scan tree stores it as ``dir.index``
+    # (web/index.ts → web.index), not as the bare dir id (GH #140).
+    if target + ".index" in module_set:
+        return target + ".index"
     return None
 
 
@@ -555,6 +561,8 @@ def build_export(buffer: GraphBuffer, root: Path) -> ExportModel:
     last_index: dict[str, list[str]] = defaultdict(list)
     # all scanned module ids, for IMPORTS resolution (GH #117)
     module_set: set[str] = set()
+    # TS path-alias map from tsconfig.json (GH #139); empty when no tsconfig.
+    alias_map = _load_tsconfig_paths(root)
 
     # Pass 1: entities + resolution index
     for node in buffer.directories():
@@ -580,10 +588,6 @@ def build_export(buffer: GraphBuffer, root: Path) -> ExportModel:
                     )
                 )
                 last_index[sym.name.rsplit(".", 1)[-1]].append(eid)
-
-    # TS path-alias map (GH #139): read once from a single root tsconfig.json.
-    # Empty when absent/unparseable — _resolve_module then behaves as before.
-    alias_map = _load_tsconfig_paths(root)
 
     # Pass 2: edges (CALLS + INHERITS), resolved against the global index
     edges: list[Edge] = []
@@ -648,7 +652,31 @@ def build_export(buffer: GraphBuffer, root: Path) -> ExportModel:
     # symbols (const / interface / type_alias) imported by name that are
     # otherwise zero-edge and get falsely flagged orphan. Namespace (`*`)
     # imports are skipped (they need per-usage member tracking, out of scope).
+    #
+    # Barrel re-export propagation (GH #140): a barrel module re-exports names
+    # it does NOT define locally (``export { X } from "./mod"``). When an
+    # import resolves to such a barrel, ``cand = barrel.X`` misses (X is not a
+    # local entity). A pre-pass built ``reexport_map`` (barrel_module →
+    # {exported_name: source_module}); here we follow the chain to the real
+    # definition module. Wildcard ``export * from`` is excluded (no member
+    # tracking, documented skip). The ``visited`` set bounds chained barrels
+    # (A→B→C→def) and breaks cycles (A↔B) — no ghost edges, no hang.
     entity_ids = {e.id for e in entities}
+    # Re-export pre-pass: barrel_module → {exported_name: source_module}.
+    reexport_map: dict[str, dict[str, str]] = defaultdict(dict)
+    for node in buffer.directories():
+        for pr in node.parse_results:
+            module = _module_of(pr.path, root)
+            for imp in pr.imports:
+                if not imp.is_reexport:
+                    continue
+                _rq, target = _resolve_module(imp.module, module, module_set, alias_map)
+                if not target:
+                    continue
+                for name in imp.names:
+                    if not name or name == "*":
+                        continue
+                    reexport_map[module][name] = target
     seen_refs: set[tuple[str, str]] = set()  # dedup (src-module, dst-entity)
     for node in buffer.directories():
         for pr in node.parse_results:
@@ -660,7 +688,17 @@ def build_export(buffer: GraphBuffer, root: Path) -> ExportModel:
                 for name in imp.names:
                     if not name or name == "*":
                         continue
-                    cand = f"{target}.{name}"
+                    cand_target = target
+                    cand = f"{cand_target}.{name}"
+                    # Follow the barrel re-export chain to the real definition.
+                    visited = {cand_target}
+                    while cand not in entity_ids:
+                        nxt = reexport_map.get(cand_target, {}).get(name)
+                        if not nxt or nxt in visited:
+                            break  # no re-export, or cycle — give up honestly
+                        visited.add(nxt)
+                        cand_target = nxt
+                        cand = f"{cand_target}.{name}"
                     if cand not in entity_ids or (module, cand) in seen_refs:
                         continue
                     seen_refs.add((module, cand))

--- a/src/codeindex/parser.py
+++ b/src/codeindex/parser.py
@@ -144,6 +144,7 @@ class Import:
     is_from: bool = False
     alias: str | None = None  # Added in v0.9.0 for LoomGraph integration
     line: int = 0  # 1-based source line for IMPORTS edge source_id (GH #117)
+    is_reexport: bool = False  # GH #140: TS `export { X } from "./mod"` (barrel re-export)
 
     def to_dict(self) -> dict:
         """Convert Import to JSON-serializable dict."""
@@ -153,6 +154,7 @@ class Import:
             "is_from": self.is_from,
             "alias": self.alias,
             "line": self.line,
+            "is_reexport": self.is_reexport,
         }
 
 

--- a/src/codeindex/parsers/typescript/imports.py
+++ b/src/codeindex/parsers/typescript/imports.py
@@ -150,9 +150,15 @@ def _parse_export_as_import(
 
     if module and has_from:
         if is_wildcard:
-            imports.append(Import(module=module, names=["*"], is_from=True, line=node.start_point[0] + 1))
+            imports.append(Import(
+                module=module, names=["*"], is_from=True,
+                line=node.start_point[0] + 1, is_reexport=True,
+            ))
         elif names:
-            imports.append(Import(module=module, names=names, is_from=True, line=node.start_point[0] + 1))
+            imports.append(Import(
+                module=module, names=names, is_from=True,
+                line=node.start_point[0] + 1, is_reexport=True,
+            ))
 
     return imports
 

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -699,6 +699,224 @@ def test_ts_path_alias_multi_target(tmp_path) -> None:
     assert e.resolution_qualifier == "resolved"
 
 
+
+
+# --------------------------------------------------------------------------- #
+# TS barrel resolution (GH #140) — `from "."` / `from "./sub"` + re-export
+# Independent tmp_path fixtures. `from "."` (current dir's index.ts) was routed
+# through the Python PEP 328 branch and produced the right directory id, but
+# _resolve_module had no `.index` fallback (only `.__init__`), so barrel
+# IMPORTS/REFERENCES edges were dropped. Named re-exports (`export { X } from
+# "./mod"` in a barrel) were indistinguishable from regular imports, so
+# `import { X } from "."` reaching a barrel could not follow the re-export to
+# the real definition module. Wildcard `export * from` stays out of scope.
+# --------------------------------------------------------------------------- #
+def test_ts_from_dot_resolves_to_index(tmp_path) -> None:
+    """GH #140: ``import { foo } from "."`` (web/main.ts) targets the current
+    directory's ``index.ts``. The PEP 328 branch yields the dir id ``web``;
+    the new ``.index`` fallback resolves it to ``web.index``. Before #140 there
+    was no `.index` fallback (only `.__init__`), so the barrel module never
+    resolved → zero IMPORTS/REFERENCES edges → orphan false-positive."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    web.mkdir()
+    (web / "index.ts").write_text("export function foo(): number { return 1; }\n")
+    (web / "main.ts").write_text(
+        'import { foo } from ".";\nexport function run() { return foo(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    imp = _edge(model, "web.main", dst="web.index", kind="IMPORTS")
+    assert imp is not None, "from '.' IMPORTS edge missing"
+    assert imp.resolution_qualifier == "resolved"
+    assert imp.dst_raw == "."
+
+    ref = _edge(model, "web.main", dst="web.index.foo", kind="REFERENCES")
+    assert ref is not None, "from '.' REFERENCES edge missing"
+
+
+def test_ts_from_subdir_resolves_to_index(tmp_path) -> None:
+    """GH #140: ``import { foo } from "./components"`` targets a subdirectory
+    whose ``index.ts`` is the module. ``./components`` → dir id
+    ``web.components`` → ``.index`` fallback → ``web.components.index``."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    comp = web / "components"
+    comp.mkdir(parents=True)
+    (comp / "index.ts").write_text("export function foo(): number { return 1; }\n")
+    (web / "main.ts").write_text(
+        'import { foo } from "./components";\nexport function run() { return foo(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    e = _edge(model, "web.main", dst="web.components.index", kind="IMPORTS")
+    assert e is not None, "from './subdir' IMPORTS edge missing"
+    assert e.resolution_qualifier == "resolved"
+
+
+def test_ts_barrel_named_reexport_propagates(tmp_path) -> None:
+    """GH #140 core: barrel re-export propagation. ``web/index.ts`` does
+    ``export { fetchUser } from "./api"`` (re-exports api's symbol — it does
+    NOT define ``fetchUser`` locally). Downstream ``import { fetchUser } from
+    "."`` resolves the module to ``web.index`` but ``web.index.fetchUser`` is
+    not a local entity. The re-export pre-pass builds
+    ``{web.index: {fetchUser: web.api}}`` and Pass 4 follows the chain to the
+    real definition ``web.api.fetchUser``. Without this, ``fetchUser`` got zero
+    in-edges → falsely orphan downstream."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    web.mkdir()
+    (web / "api.ts").write_text("export function fetchUser(): number { return 1; }\n")
+    (web / "index.ts").write_text('export { fetchUser } from "./api";\n')
+    (web / "main.ts").write_text(
+        'import { fetchUser } from ".";\nexport function run() { return fetchUser(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    # module resolves to the barrel
+    imp = _edge(model, "web.main", dst="web.index", kind="IMPORTS")
+    assert imp is not None, "barrel IMPORTS edge missing"
+
+    # REFERENCES edge follows the re-export to the real definition module
+    ref = _edge(model, "web.main", dst="web.api.fetchUser", kind="REFERENCES")
+    assert ref is not None, "barrel re-export REFERENCES edge missing"
+    assert ref.dst_raw == "..fetchUser"  # dst_raw = imp.module + "." + name = "." + "fetchUser"
+
+
+def test_ts_barrel_chained_reexport(tmp_path) -> None:
+    """GH #140: chained barrels (A → B → C → definition). ``web/index.ts``
+    re-exports from ``./b``, which re-exports from ``./c``, which defines
+    ``foo``. Pass 4's while-loop follows the chain through two barrels to
+    ``web.c.foo``."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    web.mkdir()
+    (web / "c.ts").write_text("export function foo(): number { return 1; }\n")
+    (web / "b.ts").write_text('export { foo } from "./c";\n')
+    (web / "index.ts").write_text('export { foo } from "./b";\n')
+    (web / "main.ts").write_text(
+        'import { foo } from ".";\nexport function run() { return foo(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    ref = _edge(model, "web.main", dst="web.c.foo", kind="REFERENCES")
+    assert ref is not None, "chained barrel re-export REFERENCES edge missing"
+
+
+def test_ts_barrel_reexport_cycle_safe(tmp_path) -> None:
+    """GH #140 guard: cyclic re-exports (a re-exports from b, b re-exports
+    from a) must terminate — the ``visited`` set breaks the cycle — and emit
+    NO REFERENCES edge for the unresolved name (honest unresolved, no hang, no
+    ghost edge)."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    web.mkdir()
+    # Neither a nor b defines `foo` locally — they only re-export each other.
+    (web / "a.ts").write_text('export { foo } from "./b";\n')
+    (web / "b.ts").write_text('export { foo } from "./a";\n')
+    (web / "index.ts").write_text('export { foo } from "./a";\n')
+    (web / "main.ts").write_text(
+        'import { foo } from ".";\nexport function run() { return 0; }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    refs = [
+        e for e in model.edges
+        if e.kind == "REFERENCES" and e.src == "web.main" and e.dst and "foo" in e.dst
+    ]
+    assert refs == [], f"cyclic re-export must not manufacture a foo edge: {refs}"
+
+
+def test_ts_barrel_wildcard_still_skipped(tmp_path) -> None:
+    """GH #140 guard: wildcard ``export * from "./api"`` in a barrel is still
+    skipped (documented out-of-scope at :502-503 — needs cross-file member
+    tracking). The barrel module IMPORTS edge IS emitted; the propagated
+    REFERENCES edge for ``foo`` is NOT. Must not crash and must not
+    manufacture a ghost edge."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    web = tmp_path / "web"
+    web.mkdir()
+    (web / "api.ts").write_text("export function foo(): number { return 1; }\n")
+    (web / "index.ts").write_text('export * from "./api";\n')
+    (web / "main.ts").write_text(
+        'import { foo } from ".";\nexport function run() { return foo(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    imp = _edge(model, "web.main", dst="web.index", kind="IMPORTS")
+    assert imp is not None, "wildcard barrel IMPORTS edge missing"
+
+    ref = _edge(model, "web.main", dst="web.api.foo", kind="REFERENCES")
+    assert ref is None, "wildcard re-export must NOT propagate (out of scope)"
+
+
+def test_ts_barrel_reexport_via_alias(tmp_path) -> None:
+    """GH #139 + #140 interaction: a barrel re-export using an alias specifier
+    (``export { fetchUser } from "@/api"``). The re-export pre-pass calls
+    _resolve_module with ``alias_map``, so the alias expands before the barrel
+    table is built, and Pass 4 follows the chain to ``src.api.fetchUser``.
+    Without #139 landing first, this re-export target would be unresolved."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [typescript]\n"
+    )
+    (tmp_path / "tsconfig.json").write_text(
+        json.dumps({"compilerOptions": {"paths": {"@/*": ["src/*"]}}})
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "api.ts").write_text("export function fetchUser(): number { return 1; }\n")
+    (src / "index.ts").write_text('export { fetchUser } from "@/api";\n')
+    (src / "main.ts").write_text(
+        'import { fetchUser } from ".";\nexport function run() { return fetchUser(); }\n'
+    )
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    ref = _edge(model, "src.main", dst="src.api.fetchUser", kind="REFERENCES")
+    assert ref is not None, "barrel re-export via alias REFERENCES edge missing"
+
+
+def test_python_from_dot_still_uses_init(tmp_path) -> None:
+    """GH #140 guard: Python ``from . import X`` must still resolve to the
+    ``__init__`` module (NOT the TS ``.index`` fallback). ``.__init__`` is
+    checked before ``.index`` in ``_check_fallbacks`` so a (pathological)
+    mixed Python+TS dir resolves to the Python package. This re-asserts the
+    #133 ``__init__`` path is unaffected by the new ``.index`` branch."""
+    (tmp_path / ".codeindex.yaml").write_text(
+        "version: 1\nlanguages: [python]\n"
+    )
+    pkg = tmp_path / "pkg"
+    sub = pkg / "sub"
+    sub.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (sub / "__init__.py").write_text("")
+    (sub / "svc.py").write_text("def s():\n    return 1\n")
+    (sub / "cli.py").write_text("from . import svc\n")
+    config = Config.load(tmp_path / ".codeindex.yaml")
+    model = build_export(walk_and_parse(tmp_path, config), tmp_path)
+
+    e = _edge(model, "pkg.sub.cli", dst="pkg.sub.__init__", kind="IMPORTS")
+    assert e is not None, "Python from . import X edge missing"
+    assert e.resolution_qualifier == "resolved"
+    assert e.dst == "pkg.sub.__init__"  # NOT pkg.sub.index
 # --------------------------------------------------------------------------- #
 # whole-file invariants
 # --------------------------------------------------------------------------- #

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -82,6 +82,7 @@ class TestImportSerialization:
             "is_from": True,
             "alias": None,  # Epic 10: Added alias field
             "line": 0,  # GH #117: default when parser doesn't fill it
+            "is_reexport": False,  # GH #140: barrel re-export flag
         }
 
     def test_import_to_dict_no_names(self):


### PR DESCRIPTION
## What

Fixes #140. Two gaps left TS barrel modules (`index.ts`) with zero IMPORTS / REFERENCES edges → downstream `loomgraph topology` orphan false-positives. Parallel to #139 (both are Pass 4 module-resolution gaps) but mechanically orthogonal.

## How

**Gap 1 — no TS `.index` barrel fallback.** `import { X } from "."` (current directory's `index.ts`) was routed through the Python PEP 328 branch — which correctly yields the directory id — but `_resolve_module` had no TS `.index` fallback (only Python `.__init__`), so the barrel module never resolved. `_check_fallbacks` now has a `.index` fallback **after** `.__init__` (mixed Python+TS dirs stay Python).

**Gap 2 — named re-exports indistinguishable from regular imports.** `export { X } from "./mod"` in a barrel re-exports a symbol the barrel doesn't define locally, so `cand = barrel.X` misses and the edge is dropped. `Import` now carries an `is_reexport` flag set by the TS parser's `_parse_export_as_import`; Pass 4 builds a `reexport_map` (barrel → {name: source_module}) pre-pass and follows re-export chains (barrel → source, chained barrels A→B→C→def, cycle-breaking via a `visited` set) to the real definition entity. `dst_raw` still preserves the user-written specifier.

## Scope

Wildcard `export * from` remains out of scope (documented skip — needs cross-file member tracking). Stacks on #139 (the re-export pre-pass consumes `alias_map`); includes the interaction test `test_ts_barrel_reexport_via_alias`. Schema stays v1 (resolver-internal + additive REFERENCES edges, same class as #128).

## Tests

8 new `tmp_path` tests: `from "."` → index · `from "./sub"` → sub.index · named re-export propagates · chained re-export · cycle-safe · wildcard still skipped · re-export via alias (#139+#140) · Python `from .` still uses `__init__` (guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
