### PR TITLE
docs(install): align upgrade hints to pipx (the recommended path)

### DIFF
--- a/FOR_LOOMGRAPH.md
+++ b/FOR_LOOMGRAPH.md
@@ -5,8 +5,9 @@
 ## 🚀 TL;DR
 
 ```bash
-# 安装 codeindex
-pip install ai-codeindex[all]
+# 安装 codeindex (终端用户: pipx install loomgraph 会自动拉取 ai-codeindex,
+# 无需单独安装 —— 见 README ADR-009。以下仅 LoomGraph 开发者直接调用 CLI 时需要)
+pipx install ai-codeindex[all]
 
 # 解析单个文件，输出 JSON
 codeindex parse src/user.py | jq .

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,7 @@ When using codeindex:
 
 3. **Keep Updated**
    ```bash
-   pip install --upgrade ai-codeindex
+   pipx upgrade ai-codeindex
    ```
 
 4. **Validate Inputs**

--- a/docs/guides/git-hooks-integration.md
+++ b/docs/guides/git-hooks-integration.md
@@ -176,7 +176,7 @@ All checks passed!
 **Architecture** (v0.23.0+): Thin wrapper pattern
 - Shell script (~30 lines): loop guard + venv activation
 - Python logic via `codeindex hooks run post-commit`: all business logic
-- **Upgrade path**: `pip install --upgrade ai-codeindex` automatically updates hook behavior (no need to reinstall hooks)
+- **Upgrade path**: `pipx upgrade ai-codeindex` automatically updates hook behavior (no need to reinstall hooks)
 
 **Features**:
 - Analyzes commit changes (`codeindex affected`)
@@ -542,7 +542,7 @@ codeindex hooks run post-commit (Python, in cli_hooks.py)
 ```
 
 **Upgrade behavior**:
-- `pip install --upgrade ai-codeindex` → Python logic auto-updates, no hook reinstall needed
+- `pipx upgrade ai-codeindex` → Python logic auto-updates, no hook reinstall needed
 - `codeindex hooks install --force` → only needed if shell wrapper itself changes (rare)
 - Hooks are marked with `# codeindex-managed hook` comment
 

--- a/src/codeindex/cli_hooks.py
+++ b/src/codeindex/cli_hooks.py
@@ -455,7 +455,7 @@ def run_post_commit_hook() -> int:
 
     This is called by the thin wrapper shell script via
     `codeindex hooks run post-commit`. All logic lives here so that
-    `pip install --upgrade` automatically updates the behavior.
+    `pipx upgrade ai-codeindex` automatically updates the behavior.
 
     Returns:
         Exit code (0 = success)
@@ -775,7 +775,7 @@ def run_hook(hook_name: str):
 
     This is not intended for direct user invocation.
     The shell hook script delegates to this command so that
-    hook logic can be updated via pip install --upgrade.
+    hook logic can be updated via pipx upgrade ai-codeindex.
 
     Example: codeindex hooks run post-commit
     """


### PR DESCRIPTION
## What

Since v0.25.0 (B2) the recommended install is `pipx install ai-codeindex` and `pip install --user` is the documented fallback. But several secondary spots still told users to upgrade via `pip install --upgrade ai-codeindex` — which does **not** update a pipx-installed CLI (pipx bins are isolated). Align them to `pipx upgrade ai-codeindex`.

## Changed

| File | Before → After |
|------|----------------|
| `SECURITY.md` | `pip install --upgrade` → `pipx upgrade` |
| `docs/guides/git-hooks-integration.md` (×2) | `pip install --upgrade` → `pipx upgrade` |
| `src/codeindex/cli_hooks.py` (2 docstrings) | `pip install --upgrade` → `pipx upgrade` |
| `FOR_LOOMGRAPH.md` | `pip install ai-codeindex[all]` → `pipx install` + ADR-009 note |

## Intentionally unchanged

- `README.md` / `README_zh.md` `pip install --user` — the explicit fallback (\"“don’t have pipx\"”)
- `pip install -e \".[all]\"` — from-source / dev editable install (not a user install)
- CI yaml `pip install ai-codeindex[all]` (`docs/guides/advanced-usage.md`) — standard in CI runners
- `pip install ruff` (`cli_hooks.py`) — a different package

No code behavior change; docs + docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)